### PR TITLE
make python version explicit

### DIFF
--- a/bambam.py
+++ b/bambam.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #Copyright (C) 2007-2008 Don Brown 2010 Spike Burch <spikeb@gmail.com>
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
The current version of bambam is incompatible with python3.

Unfortunately, I don't know python enough
to make the script compatible with python3.

Making the python version explicit is the only way
to launch bambam on systems that have python3 as the default version.