### PR TITLE
Added user warning of CAPSLOCK and NUMLOCK changes

### DIFF
--- a/bambam.py
+++ b/bambam.py
@@ -86,7 +86,7 @@ def load_items(lst, blacklist, load_function):
 
 # Processes events
 def input(events, quit_pos):
-    global sequence, mouse_down, sound_muted, caps_on
+    global sequence, mouse_down, sound_muted, caps_on, num_lock
     for event in events: 
         if event.type == QUIT: 
             sys.exit(0)
@@ -97,12 +97,17 @@ def input(events, quit_pos):
             if event.type == KEYDOWN:
                 if event.key == pygame.K_CAPSLOCK:
                     caps_on = True
+                if event.key == pygame.K_NUMLOCK:
+                    num_lock = True
                 if is_alpha(event.key):
                     sequence += chr(event.key)
                     if sequence.find('quit') > -1:
                         if caps_on:
                             sys.stdout.write('\nYour CAPSLOCK may have been '
                                 'reversed! Be sure to check CAPSLOCK now.\n\n')
+                        if num_lock:
+                            sys.stdout.write('\nYour NUMLOCK may have been '
+                                'reversed! Be sure to check NUMLOCK now.\n\n')
                         sys.exit(0)
                     elif sequence.find('unmute') > -1:
                         sound_muted = False
@@ -193,6 +198,7 @@ if not pygame.mixer: print 'Warning, sound disabled'
  
 pygame.init()
 caps_on = False
+num_lock = False
 
 # figure out the install base to use with image and sound loading
 progInstallBase = os.path.dirname(os.path.realpath(sys.argv[0]));

--- a/bambam.py
+++ b/bambam.py
@@ -86,7 +86,7 @@ def load_items(lst, blacklist, load_function):
 
 # Processes events
 def input(events, quit_pos):
-    global sequence, mouse_down, sound_muted
+    global sequence, mouse_down, sound_muted, caps_on
     for event in events: 
         if event.type == QUIT: 
             sys.exit(0)
@@ -95,9 +95,14 @@ def input(events, quit_pos):
         elif event.type == KEYDOWN or event.type == pygame.JOYBUTTONDOWN:
             # check for words like quit
             if event.type == KEYDOWN:
+                if event.key == pygame.K_CAPSLOCK:
+                    caps_on = True
                 if is_alpha(event.key):
                     sequence += chr(event.key)
                     if sequence.find('quit') > -1:
+                        if caps_on:
+                            sys.stdout.write('\nYour CAPSLOCK may have been '
+                                'reversed! Be sure to check CAPSLOCK now.\n\n')
                         sys.exit(0)
                     elif sequence.find('unmute') > -1:
                         sound_muted = False
@@ -187,6 +192,7 @@ if not pygame.font: print 'Warning, fonts disabled'
 if not pygame.mixer: print 'Warning, sound disabled'
  
 pygame.init()
+caps_on = False
 
 # figure out the install base to use with image and sound loading
 progInstallBase = os.path.dirname(os.path.realpath(sys.argv[0]));
@@ -246,3 +252,4 @@ for i in range(joystick_count):
 while True:
     clock.tick(60)
     quit_pos = input(pygame.event.get(), quit_pos)
+


### PR DESCRIPTION
Bambam was able to alter a bit of the computer's state during execution, namely: turning on/off CAPSLOCK and NUMLOCK.  Pygame seems ill-equipped to fix this problem, so I added a user-warning. It is activated once CAPS or NUMLOCK is turn on for the first time.  