### PR TITLE
Load arbitrary pictures

### DIFF
--- a/bambam.py
+++ b/bambam.py
@@ -309,6 +309,7 @@ class Bambam:
                        )
 
         imgs = self.glob_data('*.gif')
+        imgs += self.glob_data('*.jpg')
         self.images = self.load_items(imgs, self.args.image_blacklist, self.load_image)
 
         quit_pos = 0

--- a/bambam.py
+++ b/bambam.py
@@ -225,9 +225,17 @@ class Bambam:
         self.screen.blit(text, textpos)
 
     def glob_data(self, pattern):
+        def list_dir(path, pattern):
+            files = glob.glob(os.path.join(path, pattern))
+            dirs = [x for x in glob.glob(os.path.join(path, '*'))
+                            if os.path.isdir(x)]
+            for subdir in dirs:
+                files.extend(list_dir(subdir, pattern))
+            return files
+
         fileList = []
         for dataDir in self.dataDirs:
-            fileList.extend(glob.glob(os.path.join(dataDir, pattern)))
+            fileList.extend(list_dir(dataDir, pattern))
         return fileList
 
     def run(self):

--- a/bambam.py
+++ b/bambam.py
@@ -68,14 +68,19 @@ class Bambam:
         """
         try:
             image = pygame.image.load(fullname)
+
+            sz_x, sz_y = image.get_rect().size
+            if (sz_x > cls.IMAGE_MAX_WIDTH or sz_y > cls.IMAGE_MAX_WIDTH):
+                new_size = (cls.IMAGE_MAX_WIDTH, int(cls.IMAGE_MAX_WIDTH * (float(sz_y)/sz_x)))
+                if new_size[1] < 1:
+                    print("Image has 0 size:", fullname)
+                    raise SystemExit(message)
+
+                image = pygame.transform.scale(image, new_size)
+
         except pygame.error as message:
             print("Cannot load image:", fullname)
             raise SystemExit(message)
-
-        sz_x, sz_y = image.get_rect().size
-        if (sz_x > cls.IMAGE_MAX_WIDTH or sz_y > cls.IMAGE_MAX_WIDTH):
-            new_size = (cls.IMAGE_MAX_WIDTH, int(cls.IMAGE_MAX_WIDTH * (float(sz_y)/sz_x)))
-            image = pygame.transform.scale(image, new_size)
 
         image = image.convert()
         if colorkey is not None:

--- a/bambam.py
+++ b/bambam.py
@@ -31,6 +31,8 @@ from pygame.locals import Color, RLEACCEL, QUIT, KEYDOWN, MOUSEMOTION, MOUSEBUTT
 
 
 class Bambam:
+    IMAGE_MAX_SIZE = 700
+
     args = None
     progInstallBase = None
 
@@ -69,6 +71,12 @@ class Bambam:
         except pygame.error as message:
             print("Cannot load image:", fullname)
             raise SystemExit(message)
+
+        sz_x,sz_y = image.get_rect().size
+        if (sz_x > cls.IMAGE_MAX_SIZE or sz_y > cls.IMAGE_MAX_SIZE):
+            new_size = (cls.IMAGE_MAX_SIZE, int(cls.IMAGE_MAX_SIZE * (float(sz_y)/sz_x)))
+            image = pygame.transform.scale(image, new_size)
+
         image = image.convert()
         if colorkey is not None:
             if colorkey is -1:
@@ -300,8 +308,8 @@ class Bambam:
                        (255, 128,   0), (255,   0, 255), (0, 255, 255)
                        )
 
-        self.images = self.load_items(self.glob_data(
-            '*.gif'), self.args.image_blacklist, self.load_image)
+        imgs = self.glob_data('*.gif')
+        self.images = self.load_items(imgs, self.args.image_blacklist, self.load_image)
 
         quit_pos = 0
 

--- a/bambam.py
+++ b/bambam.py
@@ -68,14 +68,14 @@ class Bambam:
         try:
             image = pygame.image.load(fullname)
 
-            sz_x, sz_y = image.get_rect().size
-            if (sz_x > cls.IMAGE_MAX_WIDTH or sz_y > cls.IMAGE_MAX_WIDTH):
-                new_size = (cls.IMAGE_MAX_WIDTH, int(cls.IMAGE_MAX_WIDTH * (float(sz_y)/sz_x)))
-                if new_size[1] < 1:
-                    print("Image has 0 size:", fullname)
-                    raise SystemExit(message)
+            size_x, size_y = image.get_rect().size
+            if (size_x > cls.IMAGE_MAX_WIDTH or size_y > cls.IMAGE_MAX_WIDTH):
+                new_size_x = cls.IMAGE_MAX_WIDTH
+                new_size_y = int(cls.IMAGE_MAX_WIDTH * (float(size_y)/size_x))
+                if new_size_y < 1:
+                    raise pygame.error("Resized image has 0 height:", fullname)
 
-                image = pygame.transform.scale(image, new_size)
+                image = pygame.transform.scale(image, (new_size_x, new_size_y))
 
         except pygame.error as message:
             print("Cannot load image:", fullname)
@@ -230,14 +230,14 @@ class Bambam:
 
     def glob_dir(self, path, extensions):
         files = []
-        for fn in os.listdir(path):
-            fn = os.path.join(path, fn)
-            if os.path.islink(fn):
-                files.extend(self.glob_dir(fn, extensions))
+        for file_name in os.listdir(path):
+            path_name = os.path.join(path, file_name)
+            if os.path.isdir(path_name):
+                files.extend(self.glob_dir(path_name, extensions))
             else:
                 for ext in extensions:
-                    if fn.lower().endswith(ext):
-                        files.append(fn)
+                    if path_name.lower().endswith(ext):
+                        files.append(path_name)
                         break
 
         return files
@@ -245,7 +245,7 @@ class Bambam:
     def glob_data(self, extensions):
         """
         Search for files ending with any of the provided extensions. Eg:
-        extensions = ['.abc'] will be similar to `ls *.abc` in the configured 
+        extensions = ['.abc'] will be similar to `ls *.abc` in the configured
         dataDirs. Matching will be case-insensitive.
         """
         extensions = [x.lower() for x in extensions]

--- a/bambam.py
+++ b/bambam.py
@@ -31,7 +31,7 @@ from pygame.locals import Color, RLEACCEL, QUIT, KEYDOWN, MOUSEMOTION, MOUSEBUTT
 
 
 class Bambam:
-    IMAGE_MAX_SIZE = 700
+    IMAGE_MAX_WIDTH = 700
 
     args = None
     progInstallBase = None
@@ -72,9 +72,9 @@ class Bambam:
             print("Cannot load image:", fullname)
             raise SystemExit(message)
 
-        sz_x,sz_y = image.get_rect().size
-        if (sz_x > cls.IMAGE_MAX_SIZE or sz_y > cls.IMAGE_MAX_SIZE):
-            new_size = (cls.IMAGE_MAX_SIZE, int(cls.IMAGE_MAX_SIZE * (float(sz_y)/sz_x)))
+        sz_x, sz_y = image.get_rect().size
+        if (sz_x > cls.IMAGE_MAX_WIDTH or sz_y > cls.IMAGE_MAX_WIDTH):
+            new_size = (cls.IMAGE_MAX_WIDTH, int(cls.IMAGE_MAX_WIDTH * (float(sz_y)/sz_x)))
             image = pygame.transform.scale(image, new_size)
 
         image = image.convert()
@@ -224,18 +224,18 @@ class Bambam:
         textpos.centery = h
         self.screen.blit(text, textpos)
 
-    def glob_data(self, pattern):
-        def list_dir(path, pattern):
-            files = glob.glob(os.path.join(path, pattern))
-            dirs = [x for x in glob.glob(os.path.join(path, '*'))
-                            if os.path.isdir(x)]
-            for subdir in dirs:
-                files.extend(list_dir(subdir, pattern))
-            return files
+    def glob_dir(self, path, pattern):
+        files = glob.glob(os.path.join(path, pattern))
+        dirs = [x for x in glob.glob(os.path.join(path, '*')) if os.path.isdir(x)]
+        for subdir in dirs:
+            files.extend(self.glob_dir(subdir, pattern))
+        return files
 
+    def glob_data(self, patterns):
         fileList = []
         for dataDir in self.dataDirs:
-            fileList.extend(list_dir(dataDir, pattern))
+            for pattern in patterns:
+                fileList.extend(self.glob_dir(dataDir, pattern))
         return fileList
 
     def run(self):
@@ -309,15 +309,14 @@ class Bambam:
         self.sound_muted = self.args.mute
 
         self.sounds = self.load_items(self.glob_data(
-            '*.wav'), self.args.sound_blacklist, self.load_sound)
+            ['*.wav']), self.args.sound_blacklist, self.load_sound)
 
         self.colors = ((0,   0, 255), (255,   0,   0), (255, 255,   0),
                        (255,   0, 128), (0,   0, 128), (0, 255,   0),
                        (255, 128,   0), (255,   0, 255), (0, 255, 255)
                        )
 
-        imgs = self.glob_data('*.gif')
-        imgs += self.glob_data('*.jpg')
+        imgs = self.glob_data(['*.gif', '*.jpg'])
         self.images = self.load_items(imgs, self.args.image_blacklist, self.load_image)
 
         quit_pos = 0

--- a/bambam.py
+++ b/bambam.py
@@ -24,7 +24,6 @@ import sys
 import os
 import random
 import string
-import glob
 import argparse
 import fnmatch
 from pygame.locals import Color, RLEACCEL, QUIT, KEYDOWN, MOUSEMOTION, MOUSEBUTTONDOWN, MOUSEBUTTONUP


### PR DESCRIPTION
This PR implements two changes:

1. Recursively load pictures from the data directory, so that softlinks may be used to add images or sounds.
2. Dynamically resize large images so that they fit the screen.

These allow bambam to load arbitrary pictures (for example) from a photo album.

Known issues:

- A weirdly sized image (eg 1px * 200000px) can make the application crash. This is also the case without this PR, so no attempt to fix it was made
- Only jpg and gif images will be loaded


