### PR TITLE
Wait longer during test

### DIFF
--- a/test_e2e.py
+++ b/test_e2e.py
@@ -116,7 +116,7 @@ def await_welcome_screen(expect_light):
         'Polling to observe a %s screen (which means that bambam '
         'has started AND is displaying a welcome screen where the text '
         'is blue).' % comment)
-    attempt_count = 40
+    attempt_count = 400
     sleep_delay = 0.25
     for attempt in range(attempt_count):
         current_average_hsl = get_average_hsl()
@@ -134,7 +134,7 @@ def await_welcome_screen(expect_light):
 
 
 def await_blank_screen(expect_light: bool):
-    attempt_count = 40
+    attempt_count = 400
     sleep_delay = 0.25
     if expect_light:
         def check(c): return c >= 248


### PR DESCRIPTION
The e2e test sometimes flakes out waiting for Bambam to start. In case this is just caused by system slowness, bumping the timeout should help.